### PR TITLE
Can act as UDP server now

### DIFF
--- a/Rules.mk
+++ b/Rules.mk
@@ -38,7 +38,7 @@ ARCH	?= -march=armv6j -mtune=arm1176jzf-s -mfloat-abi=hard
 else ifeq ($(strip $(RASPPI)),2)
 ARCH	?= -march=armv7-a -mtune=cortex-a7 -mfpu=neon-vfpv4 -mfloat-abi=hard
 else
-ARCH	?= -march=armv7-a -mtune=cortex-a53 -mfpu=neon-vfpv4 -mfloat-abi=hard
+ARCH	?= -march=armv8-a -mtune=cortex-a53 -mfpu=neon-fp-armv8 -mfloat-abi=hard
 endif
 
 AFLAGS	+= $(ARCH) -DRASPPI=$(RASPPI) -I $(CIRCLEHOME)/include

--- a/include/circle/net/netconnection.h
+++ b/include/circle/net/netconnection.h
@@ -2,7 +2,7 @@
 // netconnection.h
 //
 // Circle - A C++ bare metal environment for Raspberry Pi
-// Copyright (C) 2015  R. Stange <rsta2@o2online.de>
+// Copyright (C) 2015-2016  R. Stange <rsta2@o2online.de>
 // 
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
@@ -51,6 +51,9 @@ public:
 	
 	virtual int Send (const void *pData, unsigned nLength, int nFlags) = 0;
 	virtual int Receive (void *pBuffer, int nFlags) = 0;
+
+	virtual int SendTo (const void *pData, unsigned nLength, int nFlags, CIPAddress	&rForeignIP, u16 nForeignPort) = 0;
+	virtual int ReceiveFrom (void *pBuffer, int nFlags, CIPAddress *pForeignIP, u16 *pForeignPort) = 0;
 
 	virtual boolean IsTerminated (void) const = 0;
 	

--- a/include/circle/net/socket.h
+++ b/include/circle/net/socket.h
@@ -2,7 +2,7 @@
 // socket.h
 //
 // Circle - A C++ bare metal environment for Raspberry Pi
-// Copyright (C) 2015  R. Stange <rsta2@o2online.de>
+// Copyright (C) 2015-2016  R. Stange <rsta2@o2online.de>
 // 
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
@@ -45,6 +45,13 @@ public:
 
 	// buffer size (and nLength) should be at least FRAME_BUFFER_SIZE, otherwise data may get lost
 	int Receive (void *pBuffer, unsigned nLength, int nFlags);
+
+	int SendTo (const void *pBuffer, unsigned nLength, int nFlags,
+		    CIPAddress &rForeignIP, u16 nForeignPort);
+
+	// buffer size (and nLength) should be at least FRAME_BUFFER_SIZE, otherwise data may get lost
+	int ReceiveFrom (void *pBuffer, unsigned nLength, int nFlags,
+			 CIPAddress *pForeignIP, u16 *pForeignPort);
 
 	const u8 *GetForeignIP (void) const;		// returns 0 if not connected
 

--- a/include/circle/net/tcpconnection.h
+++ b/include/circle/net/tcpconnection.h
@@ -2,7 +2,7 @@
 // tcpconnection.h
 //
 // Circle - A C++ bare metal environment for Raspberry Pi
-// Copyright (C) 2015  R. Stange <rsta2@o2online.de>
+// Copyright (C) 2015-2016  R. Stange <rsta2@o2online.de>
 // 
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
@@ -75,6 +75,9 @@ public:
 	
 	int Send (const void *pData, unsigned nLength, int nFlags);
 	int Receive (void *pBuffer, int nFlags);
+
+	int SendTo (const void *pData, unsigned nLength, int nFlags, CIPAddress	&rForeignIP, u16 nForeignPort);
+	int ReceiveFrom (void *pBuffer, int nFlags, CIPAddress *pForeignIP, u16 *pForeignPort);
 
 	boolean IsTerminated (void) const;
 	

--- a/include/circle/net/tcprejector.h
+++ b/include/circle/net/tcprejector.h
@@ -2,7 +2,7 @@
 // tcprejector.h
 //
 // Circle - A C++ bare metal environment for Raspberry Pi
-// Copyright (C) 2015  R. Stange <rsta2@o2online.de>
+// Copyright (C) 2015-2016  R. Stange <rsta2@o2online.de>
 // 
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
@@ -41,6 +41,10 @@ public:
 	int Close (void)						{ return -1; }
 	int Send (const void *pData, unsigned nLength, int nFlags)	{ return -1; }
 	int Receive (void *pBuffer, int nFlags)				{ return -1; }
+	int SendTo (const void *pData, unsigned nLength, int nFlags,
+		    CIPAddress	&rForeignIP, u16 nForeignPort)		{ return -1; }
+	int ReceiveFrom (void *pBuffer, int nFlags,
+			 CIPAddress *pForeignIP, u16 *pForeignPort)	{ return -1; }
 	boolean IsTerminated (void) const				{ return FALSE; }
 	void Process (void)						{ }
 

--- a/include/circle/net/transportlayer.h
+++ b/include/circle/net/transportlayer.h
@@ -2,7 +2,7 @@
 // transportlayer.h
 //
 // Circle - A C++ bare metal environment for Raspberry Pi
-// Copyright (C) 2015  R. Stange <rsta2@o2online.de>
+// Copyright (C) 2015-2016  R. Stange <rsta2@o2online.de>
 // 
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
@@ -40,6 +40,9 @@ public:
 
 	void Process (void);
 
+	// nOwnPort must not be 0
+	int Bind (u16 nOwnPort, int nProtocol);
+
 	// nOwnPort may be 0 (dynamic port assignment)
 	int Connect (CIPAddress &rIPAddress, u16 nPort, u16 nOwnPort, int nProtocol);
 
@@ -52,6 +55,13 @@ public:
 
 	// pBuffer must have size FRAME_BUFFER_SIZE
 	int Receive (void *pBuffer, int nFlags, int hConnection);
+
+	int SendTo (const void *pData, unsigned nLength, int nFlags,
+		    CIPAddress &rForeignIP, u16 nForeignPort, int hConnection);
+
+	// pBuffer must have size FRAME_BUFFER_SIZE
+	int ReceiveFrom (void *pBuffer, int nFlags, CIPAddress *pForeignIP,
+			 u16 *pForeignPort, int hConnection);
 
 	const u8 *GetForeignIP (int hConnection) const;		// returns 0 if not connected
 

--- a/include/circle/net/udpconnection.h
+++ b/include/circle/net/udpconnection.h
@@ -2,7 +2,7 @@
 // udpconnection.h
 //
 // Circle - A C++ bare metal environment for Raspberry Pi
-// Copyright (C) 2015  R. Stange <rsta2@o2online.de>
+// Copyright (C) 2015-2016  R. Stange <rsta2@o2online.de>
 // 
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
@@ -35,11 +35,9 @@ public:
 			CIPAddress	&rForeignIP,
 			u16		 nForeignPort,
 			u16		 nOwnPort);
-#if 0
 	CUDPConnection (CNetConfig	*pNetConfig,
 			CNetworkLayer	*pNetworkLayer,
 			u16		 nOwnPort);
-#endif
 	~CUDPConnection (void);
 
 	int Connect (void);
@@ -48,6 +46,9 @@ public:
 	
 	int Send (const void *pData, unsigned nLength, int nFlags);
 	int Receive (void *pBuffer, int nFlags);
+
+	int SendTo (const void *pData, unsigned nLength, int nFlags, CIPAddress	&rForeignIP, u16 nForeignPort);
+	int ReceiveFrom (void *pBuffer, int nFlags, CIPAddress *pForeignIP, u16 *pForeignPort);
 
 	boolean IsTerminated (void) const;
 	
@@ -58,6 +59,7 @@ public:
 
 private:
 	boolean m_bOpen;
+	boolean m_bActiveOpen;
 	CNetQueue m_RxQueue;
 };
 

--- a/lib/net/tcpconnection.cpp
+++ b/lib/net/tcpconnection.cpp
@@ -13,7 +13,7 @@
 //	user timeout
 //
 // Circle - A C++ bare metal environment for Raspberry Pi
-// Copyright (C) 2015  R. Stange <rsta2@o2online.de>
+// Copyright (C) 2015-2016  R. Stange <rsta2@o2online.de>
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
@@ -459,6 +459,31 @@ int CTCPConnection::Receive (void *pBuffer, int nFlags)
 	}
 
 	return nLength;
+}
+
+int CTCPConnection::SendTo (const void *pData, unsigned nLength, int nFlags,
+			    CIPAddress	&rForeignIP, u16 nForeignPort)
+{
+	// ignore rForeignIP and nForeignPort
+	return Send (pData, nLength, nFlags);
+}
+
+int CTCPConnection::ReceiveFrom (void *pBuffer, int nFlags, CIPAddress *pForeignIP, u16 *pForeignPort)
+{
+	int nResult = Receive (pBuffer, nFlags);
+	if (nResult <= 0)
+	{
+		return nResult;
+	}
+
+	if (   pForeignIP != 0
+	    && pForeignPort != 0)
+	{
+		pForeignIP->Set (m_ForeignIP);
+		*pForeignPort = m_nForeignPort;
+	}
+
+	return 0;
 }
 
 boolean CTCPConnection::IsTerminated (void) const

--- a/lib/net/udpconnection.cpp
+++ b/lib/net/udpconnection.cpp
@@ -2,7 +2,7 @@
 // udpconnection.cpp
 //
 // Circle - A C++ bare metal environment for Raspberry Pi
-// Copyright (C) 2015  R. Stange <rsta2@o2online.de>
+// Copyright (C) 2015-2016  R. Stange <rsta2@o2online.de>
 // 
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
@@ -33,27 +33,31 @@ struct TUDPHeader
 }
 PACKED;
 
+struct TUDPPrivateData
+{
+	u8	SourceAddress[IP_ADDRESS_SIZE];
+	u16	nSourcePort;
+};
+
 CUDPConnection::CUDPConnection (CNetConfig	*pNetConfig,
 				CNetworkLayer	*pNetworkLayer,
 				CIPAddress	&rForeignIP,
 				u16		 nForeignPort,
 				u16		 nOwnPort)
 :	CNetConnection (pNetConfig, pNetworkLayer, rForeignIP, nForeignPort, nOwnPort, IPPROTO_UDP),
-	m_bOpen (TRUE)
+	m_bOpen (TRUE),
+	m_bActiveOpen (TRUE)
 {
 }
-
-#if 0
 
 CUDPConnection::CUDPConnection (CNetConfig	*pNetConfig,
 				CNetworkLayer	*pNetworkLayer,
 				u16		 nOwnPort)
 :	CNetConnection (pNetConfig, pNetworkLayer, nOwnPort, IPPROTO_UDP),
-	m_bOpen (TRUE)
+	m_bOpen (TRUE),
+	m_bActiveOpen (FALSE)
 {
 }
-
-#endif
 
 CUDPConnection::~CUDPConnection (void)
 {
@@ -86,6 +90,11 @@ int CUDPConnection::Close (void)
 	
 int CUDPConnection::Send (const void *pData, unsigned nLength, int nFlags)
 {
+	if (!m_bActiveOpen)
+	{
+		return -1;
+	}
+
 	if (   nFlags != 0
 	    && nFlags != MSG_DONTWAIT)
 	{
@@ -133,8 +142,99 @@ int CUDPConnection::Receive (void *pBuffer, int nFlags)
 		return -1;
 	}
 
+	void *pParam;
 	assert (pBuffer != 0);
-	return m_RxQueue.Dequeue (pBuffer);
+	unsigned nLength = m_RxQueue.Dequeue (pBuffer, &pParam);
+	if (nLength == 0)
+	{
+		return 0;
+	}
+
+	TUDPPrivateData *pData = (TUDPPrivateData *) pParam;
+	assert (pData != 0);
+
+	delete pData;
+
+	return nLength;
+}
+
+int CUDPConnection::SendTo (const void *pData, unsigned nLength, int nFlags,
+			    CIPAddress	&rForeignIP, u16 nForeignPort)
+{
+	if (m_bActiveOpen)
+	{
+		// ignore rForeignIP and nForeignPort
+		return Send (pData, nLength, nFlags);
+	}
+
+	if (   nFlags != 0
+	    && nFlags != MSG_DONTWAIT)
+	{
+		return -1;
+	}
+
+	unsigned nPacketLength = sizeof (TUDPHeader) + nLength;		// may wrap
+	if (   nPacketLength <= sizeof (TUDPHeader)
+	    || nPacketLength > FRAME_BUFFER_SIZE)
+	{
+		return -1;
+	}
+
+	u8 *pPacketBuffer = new u8[nPacketLength];
+	assert (pPacketBuffer != 0);
+	TUDPHeader *pHeader = (TUDPHeader *) pPacketBuffer;
+
+	pHeader->nSourcePort = le2be16 (m_nOwnPort);
+	pHeader->nDestPort   = le2be16 (nForeignPort);
+	pHeader->nLength     = le2be16 (nPacketLength);
+	pHeader->nChecksum   = 0;
+	
+	assert (pData != 0);
+	assert (nLength > 0);
+	memcpy (pPacketBuffer+sizeof (TUDPHeader), pData, nLength);
+
+	assert (m_pNetConfig != 0);
+	m_Checksum.SetSourceAddress (*m_pNetConfig->GetIPAddress ());
+	m_Checksum.SetDestinationAddress (rForeignIP);
+	pHeader->nChecksum = m_Checksum.Calculate (pPacketBuffer, nPacketLength);
+
+	assert (m_pNetworkLayer != 0);
+	boolean bOK = m_pNetworkLayer->Send (rForeignIP, pPacketBuffer, nPacketLength, IPPROTO_UDP);
+	
+	delete pPacketBuffer;
+	pPacketBuffer = 0;
+
+	return bOK ? nLength : -1;
+}
+
+int CUDPConnection::ReceiveFrom (void *pBuffer, int nFlags, CIPAddress *pForeignIP, u16 *pForeignPort)
+{
+	if (nFlags != MSG_DONTWAIT)
+	{
+		return -1;
+	}
+
+	void *pParam;
+	assert (pBuffer != 0);
+	unsigned nLength = m_RxQueue.Dequeue (pBuffer, &pParam);
+	if (nLength == 0)
+	{
+		return 0;
+	}
+
+	TUDPPrivateData *pData = (TUDPPrivateData *) pParam;
+	assert (pData != 0);
+
+	if (   pForeignIP != 0
+	    && pForeignPort != 0)
+	{
+		pForeignIP->Set (pData->SourceAddress);
+		*pForeignPort = pData->nSourcePort;
+	}
+
+	delete pData;
+
+	return nLength;
 }
 
 boolean CUDPConnection::IsTerminated (void) const
@@ -156,13 +256,15 @@ int CUDPConnection::PacketReceived (const void *pPacket, unsigned nLength, CIPAd
 	m_Checksum.SetSourceAddress (rSenderIP);
 
 	// TODO: may not work with some UDP based protocol, would need receiver IP from network layer here
-	if (m_ForeignIP.IsBroadcast ())
+	if (   m_bActiveOpen
+	    && m_ForeignIP.IsBroadcast ())
 	{
 		m_Checksum.SetDestinationAddress (m_ForeignIP);
 	}
 	else
 	{
-		if (m_ForeignIP != rSenderIP)
+		if (   m_bActiveOpen
+		    && m_ForeignIP != rSenderIP)
 		{
 			return 0;
 		}
@@ -177,13 +279,19 @@ int CUDPConnection::PacketReceived (const void *pPacket, unsigned nLength, CIPAd
 	}
 	TUDPHeader *pHeader = (TUDPHeader *) pPacket;
 
-	if (   m_nOwnPort     != le2be16 (pHeader->nDestPort)
-	    || m_nForeignPort != le2be16 (pHeader->nSourcePort))
+	if (m_nOwnPort != be2le16 (pHeader->nDestPort))
 	{
 		return 0;
 	}
 
-	if (nLength < le2be16 (pHeader->nLength))
+	u16 nSourcePort = be2le16 (pHeader->nSourcePort);
+	if (   m_bActiveOpen
+	    && m_nForeignPort != nSourcePort)
+	{
+		return 0;
+	}
+
+	if (nLength < be2le16 (pHeader->nLength))
 	{
 		return -1;
 	}
@@ -197,7 +305,12 @@ int CUDPConnection::PacketReceived (const void *pPacket, unsigned nLength, CIPAd
 	nLength -= sizeof (TUDPHeader);
 	assert (nLength > 0);
 
-	m_RxQueue.Enqueue ((u8 *) pPacket + sizeof (TUDPHeader), nLength);
+	TUDPPrivateData *pData = new TUDPPrivateData;
+	assert (pData != 0);
+	rSenderIP.CopyTo (pData->SourceAddress);
+	pData->nSourcePort = nSourcePort;
+
+	m_RxQueue.Enqueue ((u8 *) pPacket + sizeof (TUDPHeader), nLength, pData);
 
 	return 1;
 }


### PR DESCRIPTION
The UDP support has been extended so that it can be used to implement
an UDP server now. Affected methods are:

CSocket::Bind()
CSocket::RecvFrom()
CSocket::SendTo()

Building is done with "-march=armv8-a -mfpu=neon-fp-armv8" for the
Raspberry Pi 3 now. This was suggested by @vanvught .
